### PR TITLE
Add for WinRM: "Session option parameters" and "Use SSL"

### DIFF
--- a/WindowsServiceManager/WindowsServiceManagerV4/DeployWindowsService.ps1
+++ b/WindowsServiceManager/WindowsServiceManagerV4/DeployWindowsService.ps1
@@ -28,6 +28,8 @@ param
 )
 Trace-VstsEnteringInvocation $MyInvocation
 
+. "$PSScriptRoot\Utility.ps1"
+
 If ($DeploymentType -eq 'Agent')
 {
     $_machines = (Get-VstsInput -Name 'Machines' -Require).Split(',').trim()
@@ -36,6 +38,9 @@ If ($DeploymentType -eq 'Agent')
     $password = (Get-VstsInput -Name 'Password' -Require )
     $securePassword = ConvertTo-SecureString $Password -AsPlainText -Force
     $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $adminLogin, $securePassword
+    $input_NewPsSessionOptionArguments = (Get-VstsInput -Name "NewPsSessionOptionArguments")
+    $sessionOption = Get-NewPSSessionOption -arguments $input_NewPsSessionOptionArguments
+    $useSSL = (Get-VstsInput -Name 'UseSSL' -AsBool)
 }
 If($InstallService)
 {
@@ -253,6 +258,14 @@ If($credential)
 {
     $invokeCommandSplat.Credential = $credential
     $invokeCommandSplat.ComputerName = $_machines
+}
+if($sessionOption)
+{
+    $invokeCommandSplat.sessionOption = $sessionOption
+}
+if($useSSL)
+{
+    $invokeCommandSplat.UseSSL = $true
 }
 Invoke-Command @invokeCommandSplat -ArgumentList $ServiceName, $TimeOut, $StopProcess, $CleanInstall, $ArtifactPath, $installationPath, $runAsCredential, $installTopShelfService, $instanceName, $installArguments
 Trace-VstsLeavingInvocation $MyInvocation

--- a/WindowsServiceManager/WindowsServiceManagerV4/task.json
+++ b/WindowsServiceManager/WindowsServiceManagerV4/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 4,
         "Minor": 1,
-        "Patch": 23
+        "Patch": 25
     },
     "instanceNameFormat": "Deploy Windows Service",
     "groups": [
@@ -61,6 +61,22 @@
             "label": "Password",
             "required": true,
             "helpMarkDown": "Password for administrator login for the target machines. It can accept variable defined in Build/Release definitions as '$(passwordVariable)'. You may mark variable type as 'secret' to secure it.",
+            "visibleRule": "DeploymentType=Agent"
+        },
+        {
+            "name": "NewPsSessionOptionArguments",
+            "type": "multiLine",
+            "label": "Session Option parameters",
+            "required": false,
+            "helpMarkDown": "Advanced options for remote session (New-PSSessionOption). For example, -SkipCACheck, -SkipCNCheck, -SkipRevocationCheck etc. For a complete list of all session options, see [this](https://aka.ms/Vsts_PS_TM_v3_NewPSSessionOptions)",
+            "visibleRule": "DeploymentType=Agent"
+        },
+        {
+            "name": "UseSSL",
+            "type": "boolean",
+            "label": "Use SSL",
+            "required": false,
+            "helpMarkDown": "Select HTTPS instead of HTTP for WINRM.",
             "visibleRule": "DeploymentType=Agent"
         },
         {

--- a/WindowsServiceManager/WindowsServiceManagerV4/utility.ps1
+++ b/WindowsServiceManager/WindowsServiceManagerV4/utility.ps1
@@ -1,0 +1,14 @@
+function Get-NewPSSessionOption {
+    [CmdletBinding()]
+    param(
+        [string] $arguments
+    )
+    Trace-VstsEnteringInvocation $MyInvocation
+    try {
+        $commandString = "New-PSSessionOption $arguments"
+        Write-Verbose "New-PSSessionOption command: $commandString"
+        return (Invoke-Expression -Command $commandString)
+    } finally {
+        Trace-VstsLeavingInvocation $MyInvocation
+    }
+}


### PR DESCRIPTION
When using agent deployment this makes it possible to set additional options for the WinRM session.